### PR TITLE
Fix links (#865)

### DIFF
--- a/addons/index.md
+++ b/addons/index.md
@@ -13,13 +13,13 @@ These are described under *Installation of Add-ons* below
 
 | Add-on Type                             | Description                                                                                                               |
 |-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| [Bindings](bindings.html)               | Bindings integrate physical hardware, external systems and web services in openHAB                                        |
-| [User Interfaces](uis.html)             | User interfaces are either native smartphone apps or web applications that access the openHAB server through the REST API |
-| [Persistence](persistence.html)         | Persistence services allow openHAB to store time series data for history-based actions or statistics                      |
-| [Actions](actions.html)                 | Actions are predefined methods for openHAB rules and scripts                                                              |
-| [Transformations](transformations.html) | Transformations are used to translate between technical and human-readable values for Items                               |
-| [Voice Services](voices.html)           | Services that provide voice enabling features, such as text-to-speech, speech-to-text etc.                                |
-| [3rd Party System Integration](io.html) | Expose openHAB to external systems                                                                                        |
+| [Bindings](/addons/#bindings)               | Bindings integrate physical hardware, external systems and web services in openHAB                                        |
+| [User Interfaces]({{base}}/configuration/#versatility)             | User interfaces are either native smartphone apps or web applications that access the openHAB server through the REST API |
+| [Persistence](/addons/#persistence)         | Persistence services allow openHAB to store time series data for history-based actions or statistics                      |
+| [Actions](/addons/#actions)                 | Actions are predefined methods for openHAB rules and scripts                                                              |
+| [Transformations](/addons/#transform) | Transformations are used to translate between technical and human-readable values for Items                               |
+| [Voice Services](/addons/#voice)           | Services that provide voice enabling features, such as text-to-speech, speech-to-text etc.                                |
+| [3rd Party System Integration](/addons/#ios) | Expose openHAB to external systems                                                                                        |
 
 ## Installation of Add-ons
 

--- a/configuration/habpanel.md
+++ b/configuration/habpanel.md
@@ -10,7 +10,7 @@ source: https://github.com/openhab/org.openhab.ui.habpanel/blob/master/doc/habpa
 
 # Designing dashboard interfaces with HABPanel
 
-The [HABPanel]({{base}}/addons/ui/habpanel/readme.html) user interface is installed by default when choosing any initial setup package, and allows the creation of user-friendly dashboards, particularly suited for (e.g. wall-mounted) tablets. These dashboards can be designed interactively in the embedded designer, rather than using configuration files.
+The HABPanel user interface is installed by default when choosing any initial setup package, and allows the creation of user-friendly dashboards, particularly suited for (e.g. wall-mounted) tablets. These dashboards can be designed interactively in the embedded designer, rather than using configuration files.
 
 Despite being similar, HABPanel's dashboards and [sitemaps]({{base}}/configuration/sitemaps.html) are separate concepts, and can be designed independently as they aren't related to each other; however, they rely and act on [items]({{base}}/concepts/items.html) which must therefore be [defined]({{base}}/configuration/items.html) first. The [demo setup package]({{base}}/configuration/packages.html#demo-package-sample-setup), available for installation when starting openHAB for the first time, defines a series of sample items and configures HABPanel with a comprehensive set of dashboards to showcase a possible end result. It's the same as the one installed on the [openHAB Demo Server](https://demo.openhab.org/){:target="_blank"}, and it may be modified without risk of breaking anything: it's the best playground to discover HABPanel's features.
 

--- a/configuration/items.md
+++ b/configuration/items.md
@@ -13,7 +13,7 @@ While a device or service might be quite specific, Items are unified substitutio
 Items can be Strings, Numbers, Switches or one of a few other basic [Item types](#type).
 A programmer can compare Item types with base variable data types of a programming language.
 
-A unique feature of openHAB Items is the ability to connect them to the outside world via [Bindings](#binding).
+A unique feature of openHAB Items is the ability to connect them to the outside world via [Bindings](/addons/#binding).
 An Item does not simply store information that is set by software (e.g., `OFF`, 3.141 or "No Error"); the information stored by an Item may also be set by actions that take place in your home.
 
 But let's not get ahead of ourselves.
@@ -27,12 +27,12 @@ The rest of this page contains details regarding Items and is structured as foll
 ## Introduction
 
 Items are basic data types and have a state which can be read from, or written to.
-Items can be linked to a [Binding](#binding) channel for interaction with the outside world.
+Items can be linked to a [Binding](/addons/#binding) channel for interaction with the outside world.
 For example, an Item bound to a sensor receives updated sensor readings and an Item linked to a light's dimmer channel can set the brightness of the light bulb.
 
 There are two methods for defining Items:
 
-1.  Through [Paper UI]({{base}}/addons/uis/paper/readme.html).
+1.  Through [Paper UI]({{base}}/configuration/ui/paperui.html).
     Generally all 2.x version Bindings can be configured through Paper UI.
     (Note that 1.x and legacy Bindings do not offer this option)
 
@@ -86,7 +86,7 @@ The last example above defines an Item with the following fields:
 - Item [icon](#icons) with the name `temperature`
 - Item belongs to [groups](#groups) `gTemperature` and `gLivingroom` (definition not shown in the example)
 - Item is [tagged](#tags) as a thermostat with the ability to set a target temperature ("TargetTemperature")
-- Item is [bound to](#binding) the openHAB Binding `knx` with binding specific settings ("1/0/15+0/0/15")
+- Item is [bound to](/addons/#binding) the openHAB Binding `knx` with binding specific settings ("1/0/15+0/0/15")
 
 The remainder of this article provides additional information regarding Item definition fields.
 
@@ -204,7 +204,7 @@ Two naming schemes are established in the community for Group names:
 ### Label
 
 Label text is used to describe an Item in a human-readable way.
-Graphical UIs will display the label text when the Item is included, e.g. in [Basic UI]({{base}}/addons/uis/basic/readme.html) in a [Sitemap]({{base}}/configuration/sitemaps.html) definition.
+Graphical UIs will display the label text when the Item is included, e.g. in [Basic UI]({{base}}/configuration/ui/basic.html) in a [Sitemap]({{base}}/configuration/sitemaps.html) definition.
 Some I/O services (e.g. the Amazon Alexa skill) also use the label to match an external voice command to an Item.
 
 In textual configurations the label, in quotation marks, appears next to the optional state presentation field in square brackets (see below).
@@ -236,7 +236,7 @@ This section provides information about what a user can expect regarding the beh
 -   A Binding may set the state of an Item to `UNDEF` if it looses communications with a Thing (for example, a Z-wave doorbell with a dead battery).
 The Binding may also set the state to `UNDEF` if an error exists in the binding configuration, or under other conditions
 
-*N.B.*  Many openHAB users find that it can be very useful to use [Persistence](/addons/#persistence) and [System started](/docs/configuration/rules-dsl.html#system-based-triggers) rules so that their systems behaves in a predictable way after an openHAB restart.
+*N.B.*  Many openHAB users find that it can be very useful to use [Persistence](/addons/#persistence) and [System started]({{base}}/configuration/rules-dsl.html#system-based-triggers) rules so that their systems behaves in a predictable way after an openHAB restart.
 
 {: #command-vs-status}
 #### Command vs. Status
@@ -530,7 +530,7 @@ Tagging is a new feature and only a few I/O add-ons have implemented it.
 The easiest way to determine if tags have been implemented in a specific add-on is to see if the add-on documentation explicitly discusses their usage.
 Tags will be ignored if no Items in the openHAB installation support it.
 
-See the [Hue Emulation Service]({{base}}/addons/integrations/hueemulation/) or [HomeKit Add-on]({{base}}/addons/integrations/homekit/) documentation for more details.
+See the [Hue Emulation Service](/addons/integrations/hueemulation/) or [HomeKit Add-on](/addons/integrations/homekit/) documentation for more details.
 
 {: #binding}
 ### Binding Configuration
@@ -648,7 +648,7 @@ Number Temperature {mysensors="24;1;V_TEMP", expire="5m,-999"}
 ```
 
 The first example shows a symbiosis of the network health Binding and the Wake-on-LAN Binding to interact with a PC.
-The second example shows a common use case for the [Expire Binding]({{base}}/addons/bindings/expire1/)
+The second example shows a common use case for the [Expire Binding](/addons/bindings/expire1/)
 where the mysensors Binding will update temperature readings regularly but the expire Binding will also listen and eventually modify the Item state.
 
 #### Parameter `autoupdate`
@@ -675,7 +675,7 @@ Profiles can be specified as a parameter for a given Channel on the Item configu
 There are some built-in Profiles available which are described in the table below.
 Some Bindings will may offer additional Profiles for Binding-specific use cases.
 If this is the case, you'll find those within the documentation of the Binding.
-Also, all [Transformation Services]({{base}}/configuration/transformations.html) provide a State Profile which allows you to do the transformation already on item-level instead doing it with a [Sitemap]({{base}}/configuration/sitemaps.html).
+Also, all [Transformation Services](/addons/#transform) provide a State Profile which allows you to do the transformation already on item-level instead doing it with a [Sitemap]({{base}}/configuration/sitemaps.html).
 You can find the documentation of these Profiles within the [Add-On documentation of the Transformation Service](/addons/#transform) you'd like to use.
 
 

--- a/configuration/paperui.md
+++ b/configuration/paperui.md
@@ -7,8 +7,6 @@ title: Configuration though Paper UI
 
 # Configuration though Paper UI
 
-Please refer to the [Paper UI Addon documentation]({{docu}}/addons/uis/paper/readme.html).
-
 The Paper UI is a new interface that helps setting up and configuring your openHAB instance.
 It does not (yet) cover all aspects, so you still need to resort to textual configuration files, but it already offers the following:
 

--- a/configuration/sitemaps.md
+++ b/configuration/sitemaps.md
@@ -9,7 +9,7 @@ title: Sitemaps
 
 In openHAB a collection of [Things]({{base}}/concepts/things.html) and [Items]({{base}}/concepts/items.html) represent physical or logical objects in the user's home automation setup.
 Sitemaps are used to select and prepare these elements in order to compose a user-oriented presentation of this setup for various User Interfaces (UIs),
-including [BasicUI]({{base}}/addons/uis/basic/readme.html),
+including [BasicUI](/configuration/ui/basic/),
 the [Android openHAB app](https://play.google.com/store/apps/details?id=org.openhab.habdroid) and others.
 
 This page is structured as follows:
@@ -476,7 +476,7 @@ See this [Tutorial](https://community.openhab.org/t/13761/1) for more details.
 
 **Technical constraints and details:**
 
-- When using rrd4j persistence, the strategy `everyMinute` (60 seconds) has to be used. Otherwise no data will be persisted (stored) and the chart will not be drawn properly (see [rrd4j Persistence](https://www.openhab.org/addons/persistence/rrd4j)).
+- When using rrd4j persistence, the strategy `everyMinute` (60 seconds) has to be used. Otherwise no data will be persisted (stored) and the chart will not be drawn properly (see [rrd4j Persistence](/addons/persistence/rrd4j)).
 - The visibility of multiple Chart objects may be toggled to simulate changing the Chart period; non-visible Chart widgets are NOT generated behind the scenes until they become visible.
 - When charting a group of item, make sure that every label is unique. If the label contains spaces, the first word of the label must be unique. Identical labels result in an empty chart.
 
@@ -527,13 +527,13 @@ This limits the possible input values, which is yet another often occurring use 
 
 ## Dynamic Sitemaps
 
-All Sitemap elements can be configured to be hidden, color highlighted or to have a [dynamic icon](/docs/configuration/items.html#icons-dynamic), depending on certain Item states.
+All Sitemap elements can be configured to be hidden, color highlighted or to have a [dynamic icon]({{base}}/configuration/items.html#icons-dynamic), depending on certain Item states.
 A few practical use cases are:
 
 - Show a battery warning if the voltage level of a device is below 30%
 - Hide further control elements for the TV if it is turned off
 - Highlight a value with a warning color if it is outside accepted limits
-- Present a special icon, depending on the state of an item (a [dynamic icon](/docs/configuration/items.html#icons-dynamic))
+- Present a special icon, depending on the state of an item (a [dynamic icon]({{base}}/configuration/items.html#icons-dynamic))
 
 ### Visibility
 
@@ -638,10 +638,10 @@ The color names above are agreed on between all openHAB UIs and are therefor you
 openHAB allows a set of icons to be assigned to the different states of an Item and therefore to be presented in a Sitemap.
 Please refer to the documentation on [Item configuration](items.html) for details.
 
-![battery-0]({{base}}/addons/iconsets/classic/icons/battery-0.png "battery-0")
-![battery-30]({{base}}/addons/iconsets/classic/icons/battery-30.png "battery-30")
-![battery-60]({{base}}/addons/iconsets/classic/icons/battery-60.png "battery-60")
-![battery-100]({{base}}/addons/iconsets/classic/icons/battery-100.png "battery-100")
+![battery-0](/iconsets/classic/battery-0.png "battery-0")
+![battery-30](/iconsets/classic/battery-30.png "battery-30")
+![battery-60](/iconsets/classic/battery-60.png "battery-60")
+![battery-100](/iconsets/classic/battery-100.png "battery-100")
 
 ## Full Example
 

--- a/configuration/things.md
+++ b/configuration/things.md
@@ -42,8 +42,8 @@ through [discovery]({{base}}/concepts/discovery.html) or by manual definition in
 
 *Note:* Some bindings do not fully support auto-discovery, others are hard to manually cover by the file based approach.
 Please consult the documentation for each binding to determine the best way to add that binding's Things and Items to openHAB.
-For some bindings (such as the [YahooWeater]({{base}}/addons/bindings/yahooweather/readme.html) binding), manual Thing definitions are required.
-Other bindings (such as the [ZWave]({{base}}/addons/bindings/zwave/readme.html) binding) currently prefer or require the discovery method.
+For some bindings, manual Thing definitions are required.
+Other bindings (such as the [ZWave](/addons/bindings/zwave/) binding) currently prefer or require the discovery method.
 
 ### Defining Things Using Discovery
 
@@ -83,7 +83,7 @@ Thing ntp:ntp:local [ hostname="de.pool.ntp.org" ]
 
 Looking at the first example:
 
-- the binding ID is "network" (using the [Network Binding]({{base}}/addons/bindings/network/readme.html))
+- the binding ID is "network" (using the [Network Binding](/addons/bindings/network/))
 - the type ID is "device", indicating the Thing is a device
 - the Thing ID is "webcam", which is an ID to uniquely identify the Thing
 - the label is "Webcam", this is how the Thing will be named in the various user interfaces

--- a/configuration/transform.md
+++ b/configuration/transform.md
@@ -10,7 +10,7 @@ title: Transformations Configuration
 Transformations are used to translate data from a cluttered or technical raw value to a processed or human-readable representation.
 They are often useful, to **interpret received Item values**, like sensor readings or state variables, and to translate them into a human-readable or better processible format.
 
-Details about the usage of Transformations and the available Transformation services can be found in the [main Transformation services article]({{base}}/addons/transformations.html).
+Details about the usage of Transformations and the available Transformation services can be found in the [main Transformation services article](/addons/#transform).
 
 Be aware that a transformation service just as any other openHAB add-on needs to be installed prior to first usage.
 

--- a/installation/qnap.md
+++ b/installation/qnap.md
@@ -2,7 +2,7 @@
 layout: documentation
 title: QNAP NAS
 ---
-
+ 
 {% include base.html %}
 
 # QNAP NAS

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -49,7 +49,7 @@ To install it, follow these simple steps:
 
 4.  Point your browser to `http://localhost:8080`.
     You should be looking at the openHAB [package selection page]({{base}}/configuration/packages.html).
-    When you've selected an appropriate package, this page will contain the [UI]({{base}}/addons/uis.html) selection screen.
+    When you've selected an appropriate package, this page will contain the UI selection screen, see [here]({{base}}/tutorial/1sttimesetup.html) for example.
 
 ### File Locations
 

--- a/tutorials/beginner/configuration.md
+++ b/tutorials/beginner/configuration.md
@@ -123,7 +123,7 @@ To demonstrate that, we'll proceed and install the Zwave binding in order to add
 However, this is a demonstration about how to install and configure add-ons.
 As mentioned before, the pure procedure to install and configure add-ons is mostly the same with other addons.**
 
-**More information about the Zwave binding and the other available bindings can be found [on the bindings page of the user manual]({{base}}/addons/bindings.html)!**
+**More information about the Zwave binding and the other available bindings can be found [on the bindings page of the user manual](/addons/#bindings)!**
 
 The installation is just like the example with the network binding above.
 Use the "Add-ons" menu item, search for the "Zwave" binding, click "INSTALL" and go directly to the "Inbox" afterwards.

--- a/tutorials/migration.md
+++ b/tutorials/migration.md
@@ -124,14 +124,14 @@ It will include the standard UIs, all transformation services and the 1.x compat
 If you are in doubt of the name of a binding, look in openhab.cfg for that binding's configurations. 
 The first part of the tag in openhab.cfg will be that name of the binding, then append a 1.
 For example, the configuration parameters for the MQTT Binding start with "mqtt" in openhab.cfg so the name of the binding is "mqtt1".
-You can find the list of bindings [here]({{base}}/addons/bindings.html).
+You can find the list of bindings [here](/addons/#bindings).
 - `ui = ` - if you intend on using PaperUI include "paper", if you use zwave I recommend "habmin". 
-The list of UIs are [here]({{base}}/addons/uis.html).
-- `action = ` - the list of action add-ons.
-- `transformation = ` - the list of transformations you use. 
+The list of UIs are [here]({{base}}/configuration/#versatility).
+- `action = ` - the list of action add-ons, see [here](/addons/#action) for list of possible actions.
+- `transformation = ` - the list of transformations you use, see [here](/addons/#transform) for a list of possible transformations. 
 Unlike in openHAB 1, one must install transformations separately.
-- `voice = ` - see [here]({{base}}/addons/voices.html)
-- `misc = ` - homekit, etc. 
+- `voice = ` - see [here](/addons/#voice)
+- `System Intergrations = ` - homekit, Azure IoT, etc., see [here](/addons/#io) 
 Do not list myopenhab/openhabcloud at this time, instructions for it are below.
 Do not install any 2.x version binding at this time.
 We want to get your current OH 1.x confiuguration running on the OH 2 core first.
@@ -292,9 +292,9 @@ Make sure you include these in your installation as well.
 
 Skip this section if all the add-ons you need have been installed already.
 
-First check the [list of add-ons that are known not to work in openHAB 2]({{base}}/addons/1xaddons.html#currently-incompatible-1x-add-ons) and make sure yours is not among them.
-
-Next install the openHAB 1.x compatibility layer using the Karaf Console instructions above.
+Be aware that not all openHAB 1.8 and earlier Add-ons are expected to be compatible with openHAB 2.
+Please note also, that support for these early bindings may not be available anymore and that for most an updated version will be availble (see [here](/addons#bindings) for a full list of supported bindings).
+Install the openHAB 1.x compatibility layer using the Karaf Console instructions above.
 
 Copy your openhab.cfg file to `$OPENHAB_CONF/services`. 
 If you are running an apt-get installed openHAB 1.x openhab.cfg is located in `/etc/openhab/configurations`.
@@ -376,7 +376,7 @@ cp $OPENHAB1_CONF/configurations/sitemaps/* $OPENHAB_CONF/sitemaps/*
 
   * Not all of the default icons that came with openHAB 1.x are available in the default set for openHAB 2. 
   If you are missing an icon in your sitemap that could be the cause. 
-  The full list of openHAB 2 icons is [here]({{base}}/addons/iconsets/classic/readme.html).
+  The full list of openHAB 2 icons is [here]({{base}}/configuration/iconsets/classic/).
 
   * Dynamic icons must have a default. 
   For example, if one has a bunch of Wunderground icons (e.g. wunderground-chanceflurries.png) there must be a `wunderground.png` icon as well.
@@ -435,7 +435,7 @@ But because this is a brand new instance there are no values in the database to 
 Browse through your sitemap methodically and identify those entries that have a missing or wrong icon. 
 Select an alternative from the [defaults]({{base}}/addons/iconsets/classic/readme.html) or copy the ones you were using from openHAB 1.x to the conf/icons/classic folder. 
 Both BasicUI and ClassicUI pull their icons from that folder. 
-For details on custom icons make sure to check the icons section in the [Items]({{base}}/configuration/items.html#icons) documentation.
+For details on custom icons make sure to check the icons section in the [Items]({{base}}/configuration/iconsets/classic/) documentation.
 One important change since openHAB 1.x is that icon filenames need to be lowercase only in openHAB 2.
 
 Once you are satisfied that your new openHAB system is up and running take a deep breath and take a break. 
@@ -481,32 +481,33 @@ A Thing represents a configurable device/system/unit, which provides different f
 Each Channel corresponds exactly to one binding configuration string (stuff in { }) in openHAB 1.x.
 
 Let's look at a concrete example. 
-The [Yahoo Weather Binding]({{base}}/addons/bindings/yahooweather/readme.html) supports exactly one Thing which takes two parameters: a WOEID location and unit.
+The [Network Binding](addons/bindings/network) (the impoved binding to the OH1 Network Health binding) supports exactly one Thing which takes one parameter: the IP number of the device on the network.
 
-Thus, as described in the Binding's readme one would manually define a Thing in a .things file (located in conf/things) with the line:
+Thus, as described in the Binding's readme one would manually define a Thing in a .things file (located in conf/things) with the line (this can also be achieved through the PaperUI:
 
 ```java
-Thing yahooweather:weather:berlin [ location=638242 ]
++//for openHAB 2 Network binding
+Thing network:pingdevice:devicename [ hostname="192.168.0.42" ]
 ```
 
-As described in the Binding's readme, three Channels are supported: temperature, humidity, and pressure. 
-Thus, rather than the old openHAB 1.x syntax:
++As described in the Binding's documentation, two Channels are supported in the version for openHAB2: online status and latency.
+The older version 1 of the Network binding only supported online status.
+Thus, rather than the old openHAB 1.x syntax (Network Health):
 
 ```java
-// openHAB 1 Syntax
-Number Temperature   { yahooweather="woeid=638242,value=temperature,unit=c" }
-Number Humidity      { yahooweather="woeid=638242,value=humidity,unit=c" }
+// openHAB 1 Syntax Network Health binding
+Switch MyDevice "MyDevice { nh="192.168.0.42"}
 ```
 
 with everything defined on in the { } part of the Item, we now merely reference the Channels.
 
 ```java
-// openHAB 2 Syntax
-Number Temperature   { channel="yahooweather:weather:berlin:temperature" }
-Number Humidity      { channel="yahooweather:weather:berlin:humidity" }
+// openHAB 2 Syntax for Network Binding
+Switch MyDevice { channel="network:pingdevice:devicename:online" }
+Number MyDeviceResponseTime { channel="network:pingdevice:devicename:latency" }
 ```
 
-As you can see, the Channel ID consists of the Thing's name, a "#" and the Channel name.
+As you can see, the Channel ID consists of the Thing's name, and the Channel name.
 
 For manually defined Things, you can find the syntax for defining a Thing on a given Item in that Binding's readme.
 
@@ -575,7 +576,7 @@ It should now show your system as being online and running openHAB 2.
 
 One is not required to use 2.x version addi-ons with openHAB 2. 
 It is highly recommended to do so as most cases where there is a 1.x and a 2.x add-on, only the 2.x binding is undergoing continued development. 
-On-the-other-hand, some of the 2.x bindings work significantly differently from their 1.x versions. See the add-on's 1.x [readme]({{base}}/addons/1xaddons.html) and 2.x [readme page]({{base}}/addons/bindings.html) to compare and contrast the two versions.
+On-the-other-hand, some of the 2.x bindings work significantly differently from their 1.x versions. See the [add-on's 1.x](https://github.com/openhab/openhab1-addons/wiki) and [openHAB 2 addons](/addons/#bindings) to compare and contrast the two versions.
 
 Identify an add-on where there is a 2.x version that you want to migrate to. 
 Begin by identifying those Items that use this binding. 


### PR DESCRIPTION
* Fixed links in uis.md

Multiple dead links fixed

* Fix links

multiple links to addons page fixed

* Delete reference to non-existing doc page

Reorg of docs made the referenced chapter obsolete

* Fixed multiple links

various links fixed

* Fixed links

links to section addons fixed
Deleted reference to yahooweather binding (now obsolete) as example for binding that requires manual thing definition.

* link fixed

link to addons section fixed

* fixed link

fixed link to UI selection screen

* Fix link

Fixed link to addons section

* Fix links, update example

Signed-off-by: Markus Lipp lipp_markus@gmail.com (github: LightIsLife)

Links to addon section and others fixed.
Old example using the now obsolete Yahooweather binding has been replaced with an example using the network binding

* delete link habpanel.md

Deleted inexisitng link

* Fix links index.md

Fixed links

* Fix link sitemaps.md  (code review)

* Update installation/windows.md (Code review)

Co-Authored-By: LightIsLife <lipp.markus@gmail.com>

* Fix typo migration.md (Code review)

* Fixed typo migration.md (code review)

* Update qnap.md